### PR TITLE
Set window.navigator.standalone=true on WKWebView

### DIFF
--- a/Microsoft.PWABuilder.IOS.Web/Resources/ios-project-src/pwa-shell/WebView.swift
+++ b/Microsoft.PWABuilder.IOS.Web/Resources/ios-project-src/pwa-shell/WebView.swift
@@ -21,6 +21,7 @@ func createWebView(container: UIView, WKSMH: WKScriptMessageHandler, WKND: WKNav
     }
     config.preferences.javaScriptCanOpenWindowsAutomatically = true
     config.allowsInlineMediaPlayback = true
+    config.preferences.setValue(true, forKey: "standalone")
     
     let webView = WKWebView(frame: calcWebviewFrame(webviewView: container, toolbarView: nil), configuration: config)
     


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Navigator

> *Navigator.standalone*
> Returns a boolean indicating whether the browser is running in standalone mode. Available on Apple's iOS Safari only.

This way it's easy to tell from javascript that you're in the PWA/app:

```javascript
// Is this running as an installed app?
const isStandalone = window.navigator.standalone === true;
```