### PR TITLE
Allow loading iFrames from srcdoc

### DIFF
--- a/Microsoft.PWABuilder.IOS.Web/Resources/ios-project-src/pwa-shell/WebView.swift
+++ b/Microsoft.PWABuilder.IOS.Web/Resources/ios-project-src/pwa-shell/WebView.swift
@@ -96,6 +96,9 @@ extension ViewController: WKUIDelegate {
     }
     // restrict navigation to target host, open external links in 3rd party apps
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if (navigationAction.request.url?.scheme == "about") {
+            return decisionHandler(.allow)
+        }
         if let requestUrl = navigationAction.request.url{
             if let requestHost = requestUrl.host {
                 let matchingHostOrigin = allowedOrigins.first(where: { requestHost.range(of: $0) != nil })


### PR DESCRIPTION
Typically its have url `about:srcdoc`

That's fixes feature detection for [es-module-shims](https://github.com/guybedford/es-module-shims) 🙂