### PR TITLE
Remove duplicate word from submit-to-app-store.md

### DIFF
--- a/submit-to-app-store.md
+++ b/submit-to-app-store.md
@@ -166,7 +166,7 @@ Once you've signed into your Apple Developer account in Xcode, dismiss the Prefe
 
 #### Uploading your package: Assign your project to your account
 
-In Xcode, choose choose `Project Navigator (📁)` -> `[your app name]` -> `Build Settings`:
+In Xcode, choose `Project Navigator (📁)` -> `[your app name]` -> `Build Settings`:
 
 ![image](https://user-images.githubusercontent.com/312936/138536316-baaad18c-5706-40bd-8a21-14e46225c6d4.png)
 


### PR DESCRIPTION
The word "choose" is used twice in a row in this file. This change just removes the duplicate.