### PR TITLE
fix: prevent blob to show old file if they share same name

### DIFF
--- a/Microsoft.PWABuilder.IOS.Web/Resources/ios-project-src/pwa-shell/WebView.swift
+++ b/Microsoft.PWABuilder.IOS.Web/Resources/ios-project-src/pwa-shell/WebView.swift
@@ -365,6 +365,11 @@ extension ViewController: WKUIDelegate, WKDownloadDelegate {
         let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let fileURL = documentsPath.appendingPathComponent(suggestedFilename)
 
+        // Remove existing file if it exists, otherwise it may show an old file/content just by having the same name.
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+
         self.openFile(url: fileURL)
         completionHandler(fileURL)
     }


### PR DESCRIPTION
See bug and discussion on: https://github.com/pwa-builder/PWABuilder/issues/4835#issuecomment-2440128785